### PR TITLE
Updated generator for better python support

### DIFF
--- a/generator/lib/APIReader.php
+++ b/generator/lib/APIReader.php
@@ -101,13 +101,28 @@ class APIReader
                 break;
             }
             // build paramater data
-            $data['params'][] = array(
-                "name" => trim($param->name),
-                "description" => trim($param->description),
-                "required" => (bool) $param->required,
-            );
-        }
-
+            if ($this->config['language'] == 'python') {
+              if ($param->required == true) {
+                $data['params_req'][] = array(
+                    "name" => trim($param->name),
+                    "description" => trim($param->description),
+                    "required" => (bool) $param->required,
+                );
+              } else {
+                $data['params_opt'][] = array(
+                    "name" => trim($param->name),
+                    "description" => trim($param->description),
+                    "required" => (bool) $param->required,
+                );
+              }
+            } else {
+              $data['params'][] = array(
+                  "name" => trim($param->name),
+                  "description" => trim($param->description),
+                  "required" => (bool) $param->required,
+              );
+            }
+          }
         return $data;
     }
 

--- a/generator/templates/method.py.twig
+++ b/generator/templates/method.py.twig
@@ -8,8 +8,7 @@
     file that was distributed with this source code.
 #}
 {% autoescape false %}
-    def {{ method.name }}(self, {% for param in method.params %}{{ param.name }}{% if param.required != true %} = ""{% endif %}{% if not loop.last %}, {% endif %}
-{% endfor %}):
+    def {{ method.name }}(self{% for param in method.params_req %}, {{ param.name }}{% endfor %}{% for param in method.params_opt %}, {{param.name}} = ""{% endfor %}):
         '''
         {{ method.description | raw }}
         '''


### PR DESCRIPTION
Updated the generator to parse out the params into required and optional for use in the python twig template. It was generating them with inappropriate python syntax where it was mixing the order of required and optional args.
